### PR TITLE
[Pocket113] Shulker Peak Height

### DIFF
--- a/xml/metadata/minecraft316.xml
+++ b/xml/metadata/minecraft316.xml
@@ -209,7 +209,7 @@
 
 		<type name="shulker-attachment" type="optional-position" id="13" />
 
-		<type name="shulker-shield-height" type="byte" id="14" />
+		<type name="shulker-shield-height" type="int" id="14" />
 
 		<type name="shulker-color" type="byte" id="15" />
 

--- a/xml/metadata/minecraft316.xml
+++ b/xml/metadata/minecraft316.xml
@@ -209,7 +209,7 @@
 
 		<type name="shulker-attachment" type="optional-position" id="13" />
 
-		<type name="shulker-shield-height" type="int" id="14" />
+		<type name="shulker-shield-height" type="byte" id="14" />
 
 		<type name="shulker-color" type="byte" id="15" />
 

--- a/xml/metadata/pocket113.xml
+++ b/xml/metadata/pocket113.xml
@@ -179,6 +179,8 @@
 		<type name="area-effect-cloud-waiting" type="int" id="62" />
 
 		<type name="area-effect-cloud-particle" type="int" id="63" />
+		
+		<type name="shulker-peak-height" type="byte" id="64" />
 
 		<type name="shulker-direction" type="byte" id="65" />
 

--- a/xml/metadata/pocket113.xml
+++ b/xml/metadata/pocket113.xml
@@ -180,7 +180,7 @@
 
 		<type name="area-effect-cloud-particle" type="int" id="63" />
 		
-		<type name="shulker-peak-height" type="byte" id="64" />
+		<type name="shulker-peak-height" type="int" id="64" />
 
 		<type name="shulker-direction" type="byte" id="65" />
 


### PR DESCRIPTION
Corresponds to that of PCMeta Shield Height and tells how far the shulker is extended.

The last few days I send quite some metadata (Really <3 for all your work, it helps me much) today I did the shulkers. 

`It seems that all the varints in the metadata are signed. Not sure if it applies everywhere in the metadata but I think so.`


